### PR TITLE
New VoxForge Importer and generation final MITADS-Speech Dataset

### DIFF
--- a/MITADS-Speech/assets/corpora_collector/mitads-speech-full.yaml
+++ b/MITADS-Speech/assets/corpora_collector/mitads-speech-full.yaml
@@ -1,0 +1,43 @@
+##
+name: 'edns-speech-full'
+version: '0.1'
+description: 'MITADS-Speech Dataset, filter audio more than 20 second'
+
+corpus2collect:
+      voxforge:
+          filter:
+              max_duration: 20
+      evalita2009:
+          filter:
+              max_duration: 20
+      mspka:
+          filter:
+              max_duration: 20
+      siwis:
+          filter:
+              max_duration: 20
+      #common_voice:
+      #    filter:
+      #        max_duration: 20
+
+      m-ailabs:
+          filter:
+              max_duration: 20
+
+      mls:
+          filter:
+              max_duration: 20
+              comments_contains:
+                    ## filter ancient work by author
+                    - Dante Alighieri
+                    - Giovanni Francesco Straparola
+                    - Niccolò Machiavelli
+                    ##filter title book that is present in m-ailabs
+                    - Novelle per un anno
+                    - Galatea
+                    - Il fu Mattia Pascal
+                    - Ritratto del Diavolo
+                    - Contessa di Karolystria
+                    - meraviglie del Duemila
+                    - Malavoglia
+      

--- a/MITADS-Speech/assets/corpora_collector/mitads-speech-full.yaml
+++ b/MITADS-Speech/assets/corpora_collector/mitads-speech-full.yaml
@@ -1,5 +1,5 @@
 ##
-name: 'edns-speech-full'
+name: 'mitads-speech-full'
 version: '0.1'
 description: 'MITADS-Speech Dataset, filter audio more than 20 second'
 

--- a/MITADS-Speech/corpora_collector.py
+++ b/MITADS-Speech/corpora_collector.py
@@ -39,6 +39,10 @@ collector_parser.add_argument('-o', '--csv_folder', type=str, default=os.path.ab
                           help='root folder of csv dataset to collect, also is root of output csv'
                                'default is root_project/MITADS-Speech-output')
 
+collector_parser.add_argument('-d', '--dataset_output', type=str, default='',
+                          help='root folder output dataset'
+                               'default is csv_folder')
+
 collector_parser.add_argument('-z', '--zip_output', type=str, default='true',
                           help='if true collect files into .zip. If false files are copyed to a folder in csv_folder')
 
@@ -164,6 +168,9 @@ def collect_datasets(config,args):
 
     zip_output = True if args.zip_output.lower()=='true' else False
     csv_corpus_rootdir = args.csv_folder
+
+    final_dataset_root = csv_corpus_rootdir if args.dataset_output=='' else  args.dataset_output
+    
     corpus2collect = config['corpus2collect']
 
 
@@ -183,7 +190,7 @@ def collect_datasets(config,args):
     final_corpora_name = config['name']
     final_corpora_version = config['version']
     output_corpora_foldername = final_corpora_name + '_' + 'v' + final_corpora_version
-    corpora_output_dir = os.path.join(csv_corpus_rootdir, output_corpora_foldername)
+    corpora_output_dir = os.path.join(final_dataset_root, output_corpora_foldername)
 
     if not path.exists(corpora_output_dir):
         print('No path "%s" - creating ...' % corpora_output_dir)

--- a/MITADS-Speech/corpora_importer.py
+++ b/MITADS-Speech/corpora_importer.py
@@ -294,7 +294,7 @@ class ArchiveImporter:
 
         ## all examples are processed, even if the resample is not necessary, the duration or other filters should be evaluated
         samples = [ [a,corpus.make_wav_resample, corpus.utterences[a]] for a in corpus.audios ] 
-        ##self.one_sample(samples[0])
+        #self.one_sample(samples[23])
         # Mutable counters for the concurrent embedded routine
         counter = get_counter()
         print(f"Converting audio files to wav {SAMPLE_RATE}hz Mono")
@@ -331,6 +331,8 @@ class ArchiveImporter:
     def one_sample(self,sample):
 
         delete_original_if_resampled = True
+        ##set to false if you want run importer more time (ex. local test)
+        delete_original_if_resampled = False 
 
         orig_filename = sample[0]
         make_wav_resample = sample[1]

--- a/MITADS-Speech/corpora_importer.py
+++ b/MITADS-Speech/corpora_importer.py
@@ -332,7 +332,7 @@ class ArchiveImporter:
 
         delete_original_if_resampled = True
         ##set to false if you want run importer more time (ex. local test)
-        delete_original_if_resampled = False 
+        #delete_original_if_resampled = False 
 
         orig_filename = sample[0]
         make_wav_resample = sample[1]

--- a/MITADS-Speech/requirements.txt
+++ b/MITADS-Speech/requirements.txt
@@ -5,3 +5,4 @@ progressbar2==3.47.0
 ## pycopy-shutil problem istall on colab
 charset_normalizer
 ds-ctcdecoder==0.9.3
+PyYAML

--- a/MITADS-Speech/siwis_importer.py
+++ b/MITADS-Speech/siwis_importer.py
@@ -103,6 +103,13 @@ class SiwisImporter(ArchiveImporter):
     # Validate and normalize transcriptions. Returns a cleaned version of the label
     # or None if it's invalid.
     def validate_label(self,label):
+        ##import unicodedata
+        ## normalize remove absent char è ò à
+        #label = (
+        #        unicodedata.normalize("NFKD", label.strip())
+        #        .encode("ascii", "ignore")
+        #        .decode("ascii", "ignore")
+        #    )
 
         label = label.replace("-", " ")
         label = label.replace("_", " ")
@@ -154,13 +161,21 @@ class SiwisImporter(ArchiveImporter):
         label = label.replace("741", "settecentoquarantuno")
         label = label.replace("103", "settecentoquarantuno")
         ######################## 
+        ##other to clean
+        label = label.replace("\ufeff", "")
+        ##
 
         if re.search(r"[0-9]|[\[\]&*{]", label) is not None:
             return None
 
-
         label = label.strip()
         label = label.lower()
+
+        ##DEBUG - decomment for checking normalization char by char
+        #DEBUG_ALPHABET = ' ,\',a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,à,è,é,ì,í,ò,ó,ô,ù,ú'.split(',')
+        #for c in label:
+        #    if(c not in DEBUG_ALPHABET):
+        #        print('CHECK char:'+ c)
 
         return label if label else None
 
@@ -168,6 +183,8 @@ if __name__ == "__main__":
 
     from corpora_importer import importer_parser
     args = importer_parser.parse_args()
+    args.download_directory = "F:\\DATASET-MODELS\\speech_dataset\\CORPORA-IT-AUDIO\\SIWIS"
+    args.csv_output_folder = "F:\\DATASET-MODELS\\speech_dataset\\new-speech-corpora-it"
 
     corpus_name=CORPUS_NAME
     archive_url = 'https://phonogenres.unige.ch/downloads/siwis_latest.zip'

--- a/MITADS-Speech/siwis_importer.py
+++ b/MITADS-Speech/siwis_importer.py
@@ -183,8 +183,8 @@ if __name__ == "__main__":
 
     from corpora_importer import importer_parser
     args = importer_parser.parse_args()
-    args.download_directory = "F:\\DATASET-MODELS\\speech_dataset\\CORPORA-IT-AUDIO\\SIWIS"
-    args.csv_output_folder = "F:\\DATASET-MODELS\\speech_dataset\\new-speech-corpora-it"
+    #args.download_directory = "F:\\DATASET-MODELS\\speech_dataset\\CORPORA-IT-AUDIO\\SIWIS"
+    #args.csv_output_folder = "F:\\DATASET-MODELS\\speech_dataset\\new-speech-corpora-it"
 
     corpus_name=CORPUS_NAME
     archive_url = 'https://phonogenres.unige.ch/downloads/siwis_latest.zip'

--- a/MITADS-Speech/siwis_importer.py
+++ b/MITADS-Speech/siwis_importer.py
@@ -20,8 +20,8 @@ class SiwisImporter(ArchiveImporter):
         text_dir = os.path.join(self.origin_data_path, self.extract_dir, "txt","IT")
         ##read transcript in prompts.txt
         transcripts = {}
-        ##cp1252 if windows os
-        encoding = 'cp1252' ## if os.name == 'nt' else 'utf-8'
+        ##encoding prompts files is cp1252
+        encoding = 'cp1252'
         ###read transcript from prompts file
         with open(os.path.join(self.origin_data_path,self.extract_dir, "prompts","ALL_IT_prompts_iso.txt"), "r",encoding=encoding) as f:
             line = f.readline()

--- a/MITADS-Speech/siwis_importer.py
+++ b/MITADS-Speech/siwis_importer.py
@@ -21,7 +21,7 @@ class SiwisImporter(ArchiveImporter):
         ##read transcript in prompts.txt
         transcripts = {}
         ##cp1252 if windows os
-        encoding = 'cp1252' if os.name == 'nt' else 'utf-8'
+        encoding = 'cp1252' ## if os.name == 'nt' else 'utf-8'
         ###read transcript from prompts file
         with open(os.path.join(self.origin_data_path,self.extract_dir, "prompts","ALL_IT_prompts_iso.txt"), "r",encoding=encoding) as f:
             line = f.readline()

--- a/MITADS-Speech/voxforge_importer.py
+++ b/MITADS-Speech/voxforge_importer.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+import time
+import os
+import re
+from corpora_importer import ArchiveImporter,Corpus,string_escape
+
+
+import urllib
+from bs4 import BeautifulSoup
+import time
+CORPUS_NAME = 'voxforge'
+
+class VoxforgeImporter(ArchiveImporter):
+
+
+    def get_corpus(self):
+        ##extract training and development datasets
+        ##do data merge, ArchiveImporter make final train/test/dev datasets
+        utterances = {}
+        audios = []
+        wav_dir  = os.path.join(self.origin_data_path, self.archive_name, "wav")
+        text_file = os.path.join(self.origin_data_path, self.archive_name, "etc","PROMPTS")  
+
+        wav_files = [f for f in os.listdir(wav_dir) if os.path.isfile(os.path.join(wav_dir, f))]
+        count=0
+
+        with open(text_file,encoding='utf-8') as f:
+            for line in f:
+                temp_2 = line.split(" ", 1)
+                ref_url = temp_2[0]
+                transcript = temp_2[1].lower()
+                transcript = transcript.replace('\n','')
+
+                temp = ref_url.split('/')
+                speaker_id = temp[0]
+                file_n = temp[-1]
+                for wav_file in wav_files:
+                    if(file_n in wav_file):
+                        ##found , is this
+                        wav_file_path = os.path.join(wav_dir,wav_file)
+                        utterances[ wav_file_path] = transcript
+                        audios.append(wav_file_path) 
+                        count +=1
+                        break
+
+
+        ##collect corpus
+        corpus = Corpus(utterances,audios)
+        #################
+        ## VoxForge need wav resample
+        ## 
+        corpus.make_wav_resample = True
+        return corpus
+
+    def get_speaker_id(self,audio_file_path):
+
+        return self.archive_name
+
+
+def get_voxforge_bad_speaker():
+
+    l = []
+    l.append("anonymous-20080504-qvg")
+    l.append("anonymous-20080723-ouv")
+    l.append("anonymous-20080725-dey")
+    l.append("Vistaus-20080718-mrm")
+    #l.append("")
+    #l.append("")
+
+
+    return l
+
+
+
+if __name__ == "__main__":
+
+    from corpora_importer import importer_parser
+    args = importer_parser.parse_args()
+
+    corpus_name=CORPUS_NAME
+    archivie_urls = []
+
+    #voxforge_url = "http://www.repository.voxforge1.org/downloads/SpeechCorpus/Trunk/Audio/Main/16kHz_16bit"
+    voxforge_url = "http://www.repository.voxforge1.org/downloads/it/Trunk/Audio/Main/16kHz_16bit/"
+
+
+    html_page = urllib.request.urlopen(voxforge_url)
+    soup = BeautifulSoup(html_page, "html.parser")
+
+    # list all links
+    archivies = [l["href"] for l in soup.find_all("a") if ".tgz" in l["href"]]
+
+    bad_speakers = get_voxforge_bad_speaker()
+    for i in range(len(archivies)):
+        archivie_url = voxforge_url + '' + archivies[i]
+
+        speaker_id = archivies[i].split('.')[0]
+
+        if(speaker_id in bad_speakers):
+            ##filter bad speaker
+            print("filter speaker {}".format(speaker_id))
+            continue
+
+        csv_append_mode = not i==0
+
+        _importer = VoxforgeImporter(corpus_name,archivie_url,data_dir=args.download_directory,output_path=args.csv_output_folder,csv_append_mode=csv_append_mode)
+        
+        try:
+            _importer.run()
+        except Exception as e:
+            print(str(e))
+            print('ARCHIVE CORRUPTED {}'.format(_importer.archive_name))
+            ##some archive is corrupted, pass
+            continue
+
+        ##sleep ...host interrupt connection
+        time.sleep(2)


### PR DESCRIPTION
1) VoxForge importer with corpora_importer util
2) Important fix other importers
3) Generation of mitads-speech dataset with all importers ( see config file: _mitads-speech-full.yaml_  )
4) Training test

Total hours we got after corpora_collector process: **349.04 hours**

COLLECTED COPRUS----MINUTES------SPEAKERS
voxforge-----------------1202.29--------1062
mls-----------------------11274.23-------59
mspka--------------------175.49---------3
m-ailabs------------------7681.88-------208
evalita2009---------------341.77---------?
siwis----------------------266.97---------16



-----------------------------------------------------------------------------------
TRAINING TEST

I Test deep speech training on this dataset, only 10 epoch with parameter of notebook training example.
**Median WER: 0.128205**

Output:
```
(ds_train_dev) ubuntu@deepspeech:~/ds_eziolotta$ python DeepSpeech.py --show_progressbar True 
--train_cudnn True 
--alphabet_config_path /home/ubuntu/deep_speech_models/italian_alphabet.txt 
--scorer /home/ubuntu/deep_speech_models/0.8/kenlm.scorer  
--feature_cache /home/ubuntu/deep_speech_models/temp_train/sources/feature_cache   
--train_files ${all_train_csv}   
--dev_files ${all_dev_csv}  
--test_files ${all_test_csv}   
--train_batch_size 64   
--dev_batch_size 64   
--test_batch_size 64   
--n_hidden 2048   
--epochs 10   
--learning_rate 0.0001   
--dropout_rate 0.4   
--max_to_keep 3   
--checkpoint_dir /home/ubuntu/deep_speech_models/ckpts/ita/deepspeech-0.9.3-checkpoint   
--summary_dir /home/ubuntu/deep_speech_models/temp_train/tboard_logs    
--early_stop 
--es_epochs 10    
--automatic_mixed_precision true    
--log_level 1
[.......]
Epoch 8 |   Training | Elapsed Time: 0:31:04 | Steps: 1483 | Loss: 25.444996
Epoch 8 | Validation | Elapsed Time: 0:01:44 | Steps: 219 | Loss: 28.228351 | Dataset: /mitads-speech-dataset/mitads-speech-full_v0.1/dev.csv
I Saved new best validating model with loss 28.228351 to: /home/ubuntu/deep_speech_models/ckpts/ita/deepspeech-0.9.3-checkpoint/best_dev-17783
--------------------------------------------------------------------------------
Epoch 9 |   Training | Elapsed Time: 0:16:20 | Steps: 1117 | Loss: 17.326802                                                                                                                                                                                                         Epoch 9 |   Training | Elapsed Time: 0:31:06 | Steps: 1483 | Loss: 23.981334
Epoch 9 | Validation | Elapsed Time: 0:01:45 | Steps: 219 | Loss: 27.230283 | Dataset: /mitads-speech-dataset/mitads-speech-full_v0.1/dev.csv
I Saved new best validating model with loss 27.230283 to: /home/ubuntu/deep_speech_models/ckpts/ita/deepspeech-0.9.3-checkpoint/best_dev-19266
--------------------------------------------------------------------------------
I FINISHED optimization in 5:30:02.122314
WARNING:tensorflow:From /home/ubuntu/miniconda3/envs/ds_train_dev/lib/python3.7/site-packages/tensorflow_core/contrib/rnn/python/ops/lstm_ops.py:597: Layer.add_variable (from tensorflow.python.keras.engine.base_layer) is deprecated and will be removed in a future version.
Instructions for updating:
Please use `layer.add_weight` method instead.
W0318 16:57:11.119858 140022320514880 deprecation.py:323] From /home/ubuntu/miniconda3/envs/ds_train_dev/lib/python3.7/site-packages/tensorflow_core/contrib/rnn/python/ops/lstm_ops.py:597: Layer.add_variable (from tensorflow.python.keras.engine.base_layer) is deprecated and will be removed in a future version.
Instructions for updating:
Please use `layer.add_weight` method instead.
I Loading best validating checkpoint from /home/ubuntu/deep_speech_models/ckpts/ita/deepspeech-0.9.3-checkpoint/best_dev-19266
I Loading variable from checkpoint: cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/bias
I Loading variable from checkpoint: cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/kernel
I Loading variable from checkpoint: global_step
I Loading variable from checkpoint: layer_1/bias
I Loading variable from checkpoint: layer_1/weights
I Loading variable from checkpoint: layer_2/bias
I Loading variable from checkpoint: layer_2/weights
I Loading variable from checkpoint: layer_3/bias
I Loading variable from checkpoint: layer_3/weights
I Loading variable from checkpoint: layer_5/bias
I Loading variable from checkpoint: layer_5/weights
I Loading variable from checkpoint: layer_6/bias
I Loading variable from checkpoint: layer_6/weights
Testing model on /mitads-speech-dataset/mitads-speech-full_v0.1/test.csv
Test epoch | Steps: 219 | Elapsed Time: 0:26:37
Test on /mitads-speech-dataset/mitads-speech-full_v0.1/test.csv - WER: 0.152582, CER: 0.053754, loss: 27.156124
--------------------------------------------------------------------------------
Best WER:
--------------------------------------------------------------------------------
WER: 0.000000, CER: 0.013514, loss: 61.034695
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/voxforge/it-0991-copy-8647.wav
 - src: "si tratta semplicemente di far rotolare attraverso i boschi questi macigni"
 - res: "si tratta semplicemente di far rotolare attraverso i boschi questi macigni "
--------------------------------------------------------------------------------
WER: 0.000000, CER: 0.012346, loss: 47.484196
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/voxforge/it-0775-copy-8726.wav
 - src: "non saprei rispose questi lanciando uno sguardo inquieto verso gli alberi giganti"
 - res: "non saprei rispose questi lanciando uno sguardo inquieto verso gli alberi giganti "
--------------------------------------------------------------------------------
WER: 0.000000, CER: 0.018182, loss: 45.007946
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/voxforge/it-1065-copy-9270.wav
 - src: "e voi credete cavaliere che egli possa sospettare di me"
 - res: "e voi credete cavaliere che egli possa sospettare di me "
--------------------------------------------------------------------------------
WER: 0.000000, CER: 0.018519, loss: 44.839371
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/siwis/IT_B_32_312.wav
 - src: "in breve si tratta di un problema di grande importanza"
 - res: "in breve si tratta di un problema di grande importanza "
--------------------------------------------------------------------------------
WER: 0.000000, CER: 0.008621, loss: 41.642883
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/siwis/IT_C_36_196.wav
 - src: "la sospensione delle vendite attuata da una catena di supermercati non sono notizie da passare all'opinione pubblica"
 - res: "la sospensione delle vendite attuata da una catena di supermercati non sono notizie da passare all'opinione pubblica "
--------------------------------------------------------------------------------
Median WER:
--------------------------------------------------------------------------------
WER: 0.128205, CER: 0.021930, loss: 27.179636
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/mls/2033_1596_001617.wav
 - src: "dalla platea e dalle gallerie i ragazzi applaudivano ogni volta che passava uno molto piccolo o uno che dai vestiti paresse povero e anche quelli che avevano delle gran capigliature ricciolute o eran vestiti di rosso o di bianco"
 - res: "dalla platea e dalle gallerie i ragazzi applaudivano ogni volta che passava uno molto piccolo o uno che dai vestiti paresse povero e anche quelli che avevano delle gran capigliature riccioluta o era un vestito di rosso e di bianco"
--------------------------------------------------------------------------------
WER: 0.128205, CER: 0.037037, loss: 23.368874
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/mls/6348_5862_000104.wav
 - src: "manco male che due portinaj in via volturno uno in via gaeta un altro in via palestro gli eran rimasti fedeli e lo aspettavano le altre copie doveva venderle cosí alla ventura girando per tutto il quartiere del macao"
 - res: "manco male che due portinai via volturno uno in via gaeta un altro via palestro gli erano rimasti fedeli e lo aspettavano le altre copie doveva venderle così alla ventura girando per tutto il quartiere del macao"
--------------------------------------------------------------------------------
WER: 0.128205, CER: 0.031390, loss: 19.807188
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/mls/8828_8610_000150.wav
 - src: "barch cioè vedi lo fai dire anche a me i dia due paja di bacchette e dàlli calosce per queste bambine le chiama barchette la mia piccina veramente si potrebbero anche chiamare cosí per non usare quella parolaccia forestiera"
 - res: "perche cioè vedi lo fai dire anche a me mi dia due paia di bacchette e dalli calosce per queste bambine le chiama barchette la mia piccina veramente si potrebbero anche chiamare così per non usare quella parolaccia forestiera"
--------------------------------------------------------------------------------
WER: 0.128205, CER: 0.018100, loss: 13.439837
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/mls/8828_8610_000109.wav
 - src: "e subito tutte le membra le si rilassarono cosí che non poté neanche sollevare le gracili mani per nascondersi il volto ma la vecchia mamma le si accostò e posandole lievemente una mano sulla spalla figlia mia le annunziò"
 - res: "e subito tutte le membra le si rilassarono così che non pote neanche sollevare le gracili mani per nascondersi il volto ma la vecchia mamma le si accostò e posando le lievemente una mano sulla spalla figlia mia e annunziò"
--------------------------------------------------------------------------------
WER: 0.129032, CER: 0.069444, loss: 90.858200
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/mls/4975_4125_000201.wav
 - src: "sospesi consci dell'orribile impressione che sua eccellenza destava in tutta la cittadinanza e infatti parve a tutti che il cielo il gajo aspetto della nostra bianca cittadina s'oscurassero a quell'apparizione ispida"
 - res: "consci dell'orribile impressione che sua eccellenza destava in tutta la cittadinanza e infatti parve a tutti che il cielo il grassetto della nostra bianca cittadina oscurassero a quell'apparizione ispida"
--------------------------------------------------------------------------------
Worst WER:
--------------------------------------------------------------------------------
WER: 2.000000, CER: 1.333333, loss: 8.697345
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/evalita2009/clean00866.wav
 - src: "due"
 - res: "e a "
--------------------------------------------------------------------------------
WER: 2.000000, CER: 0.500000, loss: 8.080779
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/evalita2009/clean02285.wav
 - src: "nove"
 - res: "no e "
--------------------------------------------------------------------------------
WER: 2.000000, CER: 0.500000, loss: 6.972440
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/evalita2009/clean02275.wav
 - src: "nove"
 - res: "no e "
--------------------------------------------------------------------------------
WER: 2.000000, CER: 0.500000, loss: 5.985777
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/evalita2009/clean02975.wav
 - src: "nove"
 - res: "no ve "
--------------------------------------------------------------------------------
WER: 2.000000, CER: 0.750000, loss: 5.125335
 - wav: file:///mitads-speech-dataset/mitads-speech-full_v0.1/audios/evalita2009/clean02895.wav
 - src: "nove"
 - res: "no me "
--------------------------------------------------------------------------------


```