### PR TITLE
fix swig not found error

### DIFF
--- a/DeepSpeech/generate_base_dockerfile.sh
+++ b/DeepSpeech/generate_base_dockerfile.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 DS_SHA=f2e9c85880dff94115ab510cde9ca4af7ee51c19
 
-rm Makefile
+rm Makefile Dockerfile.train.tmpl
 wget https://github.com/mozilla/DeepSpeech/raw/$DS_SHA/Makefile
 wget https://github.com/mozilla/DeepSpeech/raw/$DS_SHA/Dockerfile.train.tmpl
+
+# install libmagic
+sed -i '/libbz2-dev/a \\tlibmagic-dev \\' Dockerfile.train.tmpl
+
+# fix swig url
+sed -i "/^RUN git checkout \$DEEPSPEECH_SHA/a \
+RUN sed -i 's|swig/4.0.2|swig/4.1.0|' native_client/definitions.mk\n\
+RUN sed -i -E 's|community-tc.*swig(.*)amd64.*tar|github.com/mozilla/DeepSpeech/releases/download/v0.9.3/ds-swig\\\1amd64.tar|g' native_client/definitions.mk" \
+Dockerfile.train.tmpl
 
 make Dockerfile.train DEEPSPEECH_SHA=$DS_SHA
 


### PR DESCRIPTION
DeepSpeech v0.9.3 has a broken url in native_client/definitions.mk
(https://community-tc.services.mozilla.com/api/index/v1/task/project.deepspeech.swig.linux.amd64.1a4c14945012f1282c2eddc174fb7674d5295de8.0/artifacts/public/ds-swig.tar.gz)

My changes generate a dockerfile that replaces the broken url with the one used by the current DeepSpeech master version
(https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/ds-swig.linux.amd64.tar.gz)